### PR TITLE
feat: add 8-bit sound effects and mute toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Julia Sanfrancisco
+
+## Releases & deploys
+
+PR titles MUST follow Conventional Commits / semver syntax: `feat: ...`, `fix: ...`, `chore: ...`, etc.
+
+PRs are squash-merged using the PR title as the commit message, and the deploy workflow (`.github/workflows/deploy.yml`) only publishes when `semantic-release` can derive a new version from that message. A non-conforming PR title means no release and no deployment.
+
+## Workflow
+
+- Do not commit or push unless explicitly asked to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/lib/clock.svelte.ts
+++ b/src/lib/clock.svelte.ts
@@ -14,6 +14,7 @@ export default class Clock {
 	isWalking = $state(false);
 	isFlying = $state(false);
 	isSleeping = $state(false);
+	sleepDurationMs = $state(0);
 	isTimeUp = $derived(this.elapsedMinutes >= DEADLINE_MINUTES);
 
 	#timerId: ReturnType<typeof setInterval> | null = null;
@@ -44,6 +45,17 @@ export default class Clock {
 
 	public restore = (elapsedMinutes: unknown) => {
 		this.elapsedMinutes = this.#normalizeElapsedMinutes(elapsedMinutes);
+	};
+
+	public waitForWake = (): Promise<void> => {
+		return new Promise((resolve) => {
+			if (!this.isSleeping) {
+				resolve();
+				return;
+			}
+
+			this.#pendingFastForwards.push(() => resolve());
+		});
 	};
 
 	public fastForward = (hours: number): Promise<boolean> => {
@@ -128,6 +140,7 @@ export default class Clock {
 			this.isFlying = false;
 
 			if (!this.isTimeUp && this.#shouldSleep()) {
+				this.#resolveFastForwards();
 				this.#startSleep();
 				return;
 			}
@@ -141,9 +154,13 @@ export default class Clock {
 	#startSleep = () => {
 		this.isWalking = false;
 		this.isFlying = false;
-		this.isSleeping = true;
 
 		const minutesUntilWake = this.#minutesUntilWake();
+		const sleepMinutes = Math.min(minutesUntilWake, DEADLINE_MINUTES - this.elapsedMinutes);
+		this.sleepDurationMs = Math.round(
+			(sleepMinutes / FAST_FORWARD_MINUTES_PER_TICK) * TICK_INTERVAL_MS
+		);
+		this.isSleeping = true;
 		this.#targetMinutes = Math.min(DEADLINE_MINUTES, this.elapsedMinutes + minutesUntilWake);
 		this.#ensureTicker();
 	};

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { playSfx } from '$lib/sfx';
+
 	interface Props {
 		title?: string | undefined;
 		disabled?: boolean;
@@ -29,7 +31,10 @@
 	"
 	{disabled}
 	{title}
-	{onclick}
+	onclick={(event) => {
+		playSfx('click');
+		onclick?.(event);
+	}}
 >
 	{@render children?.()}
 </button>

--- a/src/lib/components/ButtonIcon.svelte
+++ b/src/lib/components/ButtonIcon.svelte
@@ -1,18 +1,36 @@
 <script lang="ts">
+	import { playSfx } from '$lib/sfx';
 	import { fade } from 'svelte/transition';
 
 	interface Props {
 		title: string;
 		disabled?: boolean;
 		active?: boolean;
+		silent?: boolean;
 		onclick?: (event: MouseEvent) => void;
 		children?: import('svelte').Snippet;
 	}
 
-	let { title, disabled = false, active = false, onclick, children }: Props = $props();
+	let {
+		title,
+		disabled = false,
+		active = false,
+		silent = false,
+		onclick,
+		children
+	}: Props = $props();
 </script>
 
-<button class="button {active ? 'button--active' : ''}" {disabled} {title} {onclick} in:fade|global>
+<button
+	class="button {active ? 'button--active' : ''}"
+	{disabled}
+	{title}
+	onclick={(event) => {
+		if (!silent) playSfx('click');
+		onclick?.(event);
+	}}
+	in:fade|global
+>
 	{@render children?.()}
 </button>
 

--- a/src/lib/components/ButtonLink.svelte
+++ b/src/lib/components/ButtonLink.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { playSfx } from '$lib/sfx';
+
 	interface Props {
 		href: string;
 		target?: string;
@@ -9,7 +11,7 @@
 	let { href, target = '', isActive = false, children }: Props = $props();
 </script>
 
-<a class="a {isActive ? 'a--active' : ''}" {target} {href}>
+<a class="a {isActive ? 'a--active' : ''}" {target} {href} onclick={() => playSfx('click')}>
 	{@render children?.()}
 </a>
 

--- a/src/lib/components/P.svelte
+++ b/src/lib/components/P.svelte
@@ -18,6 +18,7 @@
 		width: 80%; // Looks prettier at this width 🤷‍♂️
 		box-sizing: border-box;
 		color: var(--color-neutral-150);
+		text-wrap: balance;
 
 		&:first-child {
 			margin-top: 0;

--- a/src/lib/components/TerminalRows.svelte
+++ b/src/lib/components/TerminalRows.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { playSfx } from '$lib/sfx';
 	import TerminalParagraph from './TerminalParagraph.svelte';
 	import TerminalTitle from './TerminalTitle.svelte';
 	import type { TerminalRow } from './Terminal';
@@ -69,6 +70,7 @@
 
 		animationIntervalId = setInterval(() => {
 			visibleCharacters += 1;
+			if (visibleCharacters % 3 === 0) playSfx('type');
 
 			if (visibleCharacters >= totalCharacters) {
 				visibleCharacters = totalCharacters;

--- a/src/lib/icons/SoundOff.svg.svelte
+++ b/src/lib/icons/SoundOff.svg.svelte
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M4 11H10L18 4V28L10 21H4V11Z" fill="white" />
+	<path d="M22 12L30 20M30 12L22 20" stroke="white" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/src/lib/icons/SoundOn.svg.svelte
+++ b/src/lib/icons/SoundOn.svg.svelte
@@ -1,0 +1,15 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M4 11H10L18 4V28L10 21H4V11Z" fill="white" />
+	<path
+		d="M22 10C23.9 11.4 25 13.6 25 16C25 18.4 23.9 20.6 22 22"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M25 6C28.1 8.3 30 11.9 30 16C30 20.1 28.1 23.7 25 26"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+	/>
+</svg>

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -1,0 +1,274 @@
+export type SfxName =
+	| 'click'
+	| 'back'
+	| 'confirm'
+	| 'walk'
+	| 'fly'
+	| 'clue'
+	| 'alert'
+	| 'warrant'
+	| 'victory'
+	| 'gameover'
+	| 'sleep'
+	| 'type'
+	| 'arrest';
+
+type NoteSpec = {
+	offsetMs: number;
+	durationMs: number;
+	freqStart: number;
+	freqEnd?: number;
+	volume?: number;
+};
+
+type Recipe = NoteSpec[] | ((durationMs?: number) => NoteSpec[]);
+
+const STORAGE_KEY = 'sfxMuted';
+const MASTER_GAIN = 0.12;
+const ATTACK_SECONDS = 0.002;
+const RELEASE_SECONDS = 0.015;
+
+function cricketNotes(durationMs = 4400): NoteSpec[] {
+	const notes: NoteSpec[] = [];
+
+	for (let groupStart = 0; groupStart + 168 <= durationMs; groupStart += 900) {
+		for (let chirp = 0; chirp < 3; chirp++) {
+			notes.push({
+				offsetMs: groupStart + chirp * 75,
+				durationMs: 18,
+				freqStart: 4200,
+				volume: 0.25
+			});
+		}
+	}
+
+	for (let groupStart = 450; groupStart + 156 <= durationMs; groupStart += 950) {
+		for (let chirp = 0; chirp < 3; chirp++) {
+			notes.push({
+				offsetMs: groupStart + chirp * 70,
+				durationMs: 16,
+				freqStart: 3500,
+				volume: 0.2
+			});
+		}
+	}
+
+	return notes;
+}
+
+const sfxRecipes: Record<SfxName, Recipe> = {
+	click: [{ offsetMs: 0, durationMs: 20, freqStart: 1800, freqEnd: 150, volume: 0.8 }],
+	back: [{ offsetMs: 0, durationMs: 25, freqStart: 500 }],
+	confirm: [
+		{ offsetMs: 0, durationMs: 50, freqStart: 660 },
+		{ offsetMs: 60, durationMs: 90, freqStart: 990 }
+	],
+	walk: Array.from({ length: 7 }, (_, index) => ({
+		offsetMs: index * 150,
+		durationMs: 20,
+		freqStart: index % 2 === 0 ? 220 : 180,
+		volume: 0.7
+	})),
+	fly: [
+		...Array.from({ length: 28 }, (_, index) => {
+			const spoolUp = Math.round(80 * 1.18 ** Math.min(index, 8));
+			const isOffbeat = index > 8 && index % 2 === 1;
+
+			return {
+				offsetMs: index * 60,
+				durationMs: 25,
+				freqStart: isOffbeat ? Math.round(spoolUp * 0.92) : spoolUp,
+				volume: 0.7
+			};
+		}),
+		{ offsetMs: 1740, durationMs: 260, freqStart: 294, freqEnd: 392, volume: 0.5 }
+	],
+	clue: [620, 780, 540, 860, 700].map((freqStart, index) => ({
+		offsetMs: index * 65,
+		durationMs: 30,
+		freqStart,
+		volume: 0.8
+	})),
+	alert: Array.from({ length: 16 }, (_, index) => ({
+		offsetMs: index * 250,
+		durationMs: 240,
+		freqStart: index % 2 === 0 ? 240 : 360,
+		freqEnd: index % 2 === 0 ? 360 : 240,
+		volume: 0.6
+	})),
+	warrant: [
+		...Array.from({ length: 8 }, (_, index) => ({
+			offsetMs: index * 45,
+			durationMs: 18,
+			freqStart: index % 2 === 0 ? 1200 : 1500,
+			volume: 0.6
+		})),
+		{ offsetMs: 413, durationMs: 140, freqStart: 990 }
+	],
+	victory: [
+		{ offsetMs: 0, durationMs: 80, freqStart: 392, volume: 0.9 },
+		{ offsetMs: 90, durationMs: 80, freqStart: 392, volume: 0.9 },
+		{ offsetMs: 180, durationMs: 80, freqStart: 392, volume: 0.9 },
+		{ offsetMs: 270, durationMs: 300, freqStart: 523 },
+		{ offsetMs: 620, durationMs: 80, freqStart: 659, volume: 0.9 },
+		{ offsetMs: 710, durationMs: 300, freqStart: 784 },
+		{ offsetMs: 1060, durationMs: 80, freqStart: 659, volume: 0.9 },
+		{ offsetMs: 1150, durationMs: 80, freqStart: 784, volume: 0.9 },
+		{ offsetMs: 1240, durationMs: 80, freqStart: 880, volume: 0.9 },
+		{ offsetMs: 1330, durationMs: 600, freqStart: 1047 }
+	],
+	gameover: [
+		{ offsetMs: 0, durationMs: 300, freqStart: 392, freqEnd: 370, volume: 0.9 },
+		{ offsetMs: 340, durationMs: 300, freqStart: 349, freqEnd: 330, volume: 0.9 },
+		{ offsetMs: 680, durationMs: 300, freqStart: 311, freqEnd: 294, volume: 0.9 },
+		{ offsetMs: 1020, durationMs: 700, freqStart: 294, freqEnd: 208, volume: 0.9 }
+	],
+	sleep: cricketNotes,
+	type: [{ offsetMs: 0, durationMs: 12, freqStart: 1400, volume: 0.3 }],
+	arrest: [
+		...[0, 600].flatMap((blastStart) =>
+			Array.from({ length: 14 }, (_, index) => ({
+				offsetMs: blastStart + index * 35,
+				durationMs: 35,
+				freqStart: index % 2 === 0 ? 2200 : 2350,
+				volume: 0.5
+			}))
+		),
+		...Array.from({ length: 12 }, (_, index) => ({
+			offsetMs: 1300 + index * 110,
+			durationMs: 20,
+			freqStart: index % 2 === 0 ? 210 : 170,
+			volume: 0.6
+		})),
+		{ offsetMs: 2900, durationMs: 18, freqStart: 1600, freqEnd: 200, volume: 0.8 },
+		{ offsetMs: 3060, durationMs: 18, freqStart: 1600, freqEnd: 200, volume: 0.8 }
+	]
+};
+
+let audioContext: AudioContext | null = null;
+let masterGain: GainNode | null = null;
+let mutedCache: boolean | null = null;
+
+function readMuted(): boolean {
+	if (typeof window === 'undefined') return false;
+	if (mutedCache !== null) return mutedCache;
+
+	try {
+		mutedCache = window.localStorage.getItem(STORAGE_KEY) === 'true';
+	} catch {
+		mutedCache = false;
+	}
+
+	return mutedCache;
+}
+
+function getAudioContext(): AudioContext | null {
+	if (typeof window === 'undefined') return null;
+	if (audioContext !== null && masterGain !== null) return audioContext;
+
+	const AudioContextConstructor = window.AudioContext;
+	if (AudioContextConstructor === undefined) return null;
+
+	audioContext = new AudioContextConstructor();
+	masterGain = audioContext.createGain();
+	masterGain.gain.value = MASTER_GAIN;
+	masterGain.connect(audioContext.destination);
+
+	return audioContext;
+}
+
+function tone(
+	context: AudioContext,
+	startAtSeconds: number,
+	durationSeconds: number,
+	freqStart: number,
+	freqEnd = freqStart,
+	volume = 1
+): void {
+	if (masterGain === null) return;
+
+	const osc = context.createOscillator();
+	const gain = context.createGain();
+	const endAtSeconds = startAtSeconds + durationSeconds;
+	const attackEndSeconds = Math.min(startAtSeconds + ATTACK_SECONDS, endAtSeconds);
+	const releaseStartSeconds = Math.max(attackEndSeconds, endAtSeconds - RELEASE_SECONDS);
+
+	osc.type = 'square';
+	osc.frequency.setValueAtTime(freqStart, startAtSeconds);
+
+	if (freqEnd !== freqStart) {
+		osc.frequency.exponentialRampToValueAtTime(freqEnd, endAtSeconds);
+	}
+
+	gain.gain.setValueAtTime(0, startAtSeconds);
+	gain.gain.linearRampToValueAtTime(volume, attackEndSeconds);
+	gain.gain.setValueAtTime(volume, releaseStartSeconds);
+	gain.gain.exponentialRampToValueAtTime(0.0001, endAtSeconds);
+
+	osc.connect(gain);
+	gain.connect(masterGain);
+	osc.onended = () => {
+		osc.disconnect();
+		gain.disconnect();
+	};
+	osc.start(startAtSeconds);
+	osc.stop(endAtSeconds);
+}
+
+function scheduleNotes(context: AudioContext, notes: NoteSpec[]): void {
+	const now = context.currentTime;
+
+	for (const note of notes) {
+		tone(
+			context,
+			now + note.offsetMs / 1000,
+			note.durationMs / 1000,
+			note.freqStart,
+			note.freqEnd,
+			note.volume
+		);
+	}
+}
+
+export function playSfx(name: SfxName, durationMs?: number): void {
+	try {
+		if (readMuted()) return;
+
+		const context = getAudioContext();
+		if (context === null) return;
+
+		const recipe = sfxRecipes[name];
+		const notes = typeof recipe === 'function' ? recipe(durationMs) : recipe;
+
+		if (context.state === 'suspended') {
+			const requestedAt = performance.now();
+			void context
+				.resume()
+				.then(() => {
+					if (performance.now() - requestedAt < 100) scheduleNotes(context, notes);
+				})
+				.catch(() => undefined);
+			return;
+		}
+
+		scheduleNotes(context, notes);
+	} catch {
+		return;
+	}
+}
+
+export function setSfxMuted(muted: boolean): void {
+	mutedCache = muted;
+
+	if (typeof window === 'undefined') return;
+
+	try {
+		window.localStorage.setItem(STORAGE_KEY, muted ? 'true' : 'false');
+	} catch {
+		return;
+	}
+}
+
+export function isSfxMuted(): boolean {
+	return readMuted();
+}

--- a/src/lib/state/game-page.svelte.ts
+++ b/src/lib/state/game-page.svelte.ts
@@ -9,6 +9,7 @@ import {
 	type Round
 } from '$lib/game';
 import { delay, redirectTo } from '$lib/helpers';
+import { playSfx } from '$lib/sfx';
 import {
 	findSuspects,
 	Suspect,
@@ -48,6 +49,7 @@ export default class GamePageState {
 	suspectCaught = $derived(
 		!this.isTimeUp &&
 			this.isLastRound &&
+			!this.game?.roundDecoy &&
 			this.currentClueIndex === this.game?.suspect.lastRoundHidingPlace
 	);
 	isGameOver: boolean = $derived(this.suspectCaught || this.isTimeUp);
@@ -174,6 +176,7 @@ export default class GamePageState {
 	};
 
 	computeWarrant = (): void => {
+		playSfx('warrant');
 		this.warrantWasComputed = true;
 		this.game.warrants = findSuspects(
 			this.warrantSex,
@@ -189,6 +192,9 @@ export default class GamePageState {
 		this.showDescription = false;
 		this.clock.isWalking = true;
 
+		const isFinalCatch =
+			this.isLastRound && !this.game.roundDecoy && this.game.suspect.lastRoundHidingPlace === index;
+
 		if (
 			!this.trailingSceneInRoundSeen &&
 			!this.isFirstRound &&
@@ -196,6 +202,7 @@ export default class GamePageState {
 		) {
 			this.isArtworkHidden = true;
 			this.isTrailingSuspect = true;
+			playSfx('alert');
 			this.trailingSuspectScene = (
 				this.game.currentRoundIndex - 1
 			).toString() as keyof Translation['game']['trailingSuspect'];
@@ -206,13 +213,24 @@ export default class GamePageState {
 		}
 
 		this.isArtworkHidden = true;
+		playSfx('walk');
 		await this.clock.fastForward(2);
+		await this.clock.waitForWake();
 
+		if (isFinalCatch && !this.isTimeUp) {
+			this.game.suspect.caught = true;
+			sessionState.save();
+			redirectTo('/gg/');
+			return;
+		}
+
+		playSfx('clue');
 		this.currentClueIndex = index;
 		if (this.currentRound) this.artworkPath = this.currentRound.scenes[index].witness.artwork;
 	};
 
 	dismissClue = async (): Promise<void> => {
+		playSfx('back');
 		this.isArtworkHidden = true;
 		await delay(DELAY_IN_MS);
 
@@ -226,6 +244,7 @@ export default class GamePageState {
 		this.showDestinations = false;
 		this.showDescription = false;
 		this.isArtworkHidden = true;
+		playSfx('fly');
 		await this.clock.fastForward(4);
 
 		const { rounds, currentRoundIndex } = this.game;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,11 @@
 	import { PUBLIC_PLAUSIBLE_DOMAIN } from '$env/static/public';
 	import { page } from '$app/state';
 	import type { Locales } from '$i18n/i18n-types';
+	import ButtonIcon from '$lib/components/ButtonIcon.svelte';
+	import SoundOff from '$lib/icons/SoundOff.svg.svelte';
+	import SoundOn from '$lib/icons/SoundOn.svg.svelte';
 	import { applyLocale } from '$lib/player';
+	import { isSfxMuted, playSfx, setSfxMuted } from '$lib/sfx';
 	import { playerState } from '$lib/state/player.svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -12,6 +16,13 @@
 	}
 
 	let { children }: Props = $props();
+	let muted = $derived(isSfxMuted());
+
+	function toggleMuted(): void {
+		muted = !muted;
+		setSfxMuted(muted);
+		if (!muted) playSfx('confirm');
+	}
 	const browserLocaleDetector: LocaleDetector = () =>
 		typeof navigator === 'undefined' ? [] : Array.from(navigator.languages);
 
@@ -78,6 +89,16 @@
 			{@render children?.()}
 		</div>
 	{/key}
+
+	<aside class="sound-toggle">
+		<ButtonIcon silent onclick={toggleMuted} title={muted ? 'Unmute' : 'Mute'}>
+			{#if muted}
+				<SoundOff />
+			{:else}
+				<SoundOn />
+			{/if}
+		</ButtonIcon>
+	</aside>
 </div>
 
 <style lang="scss">
@@ -159,5 +180,27 @@
 		display: grid;
 		width: 100%;
 		height: 100%;
+	}
+
+	aside.sound-toggle {
+		justify-self: end;
+		align-self: start;
+		width: max-content;
+		height: max-content;
+		margin-top: 56px;
+		margin-right: var(--layout-inline);
+		z-index: 10;
+		opacity: 0.5;
+		transition: opacity 250ms;
+
+		&:hover {
+			opacity: 1;
+		}
+
+		:global(svg) {
+			display: block;
+			width: 20px;
+			height: 20px;
+		}
 	}
 </style>

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -17,6 +17,7 @@
 	import Time from '$lib/components/Time.svelte';
 	import TrailingSuspect from '$lib/components/TrailingSuspect.svelte';
 	import { getRandomValue } from '$lib/helpers';
+	import { playSfx } from '$lib/sfx';
 	import GamePageState from '$lib/state/game-page.svelte';
 	import { untrack } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -29,6 +30,10 @@
 
 	$effect(() => {
 		return untrack(() => gamePage.startClock());
+	});
+
+	$effect(() => {
+		if (gamePage.isSleeping) playSfx('sleep', gamePage.clock.sleepDurationMs);
 	});
 </script>
 

--- a/src/routes/gg/+page.svelte
+++ b/src/routes/gg/+page.svelte
@@ -15,6 +15,7 @@
 	import { delay, redirectTo } from '$lib/helpers';
 	import Continue from '$lib/icons/Continue.svg.svelte';
 	import { getCasesUntilPromotion, getRank } from '$lib/player';
+	import { playSfx } from '$lib/sfx';
 	import { playerState } from '$lib/state/player.svelte';
 	import { sessionState } from '$lib/state/session.svelte';
 	import { untrack } from 'svelte';
@@ -134,14 +135,17 @@
 
 	async function playOutroScene(): Promise<void> {
 		showDangerScene = true;
+		playSfx('alert');
 		await delay(SUSPECT_TRAIL_SCENE_DURATION);
 
 		showDangerScene = false;
 		showCaptureScene = true;
+		playSfx('arrest');
 		await delay(SUSPECT_TRAIL_SCENE_DURATION);
 
 		showCaptureScene = false;
 		hasOutroScenePlayed = true;
+		playSfx(suspectCaughtWithWarrant ? 'victory' : 'gameover');
 	}
 
 	function nextStep(): void {
@@ -168,6 +172,8 @@
 				redirectTo('/headquarters/');
 			} else if (!suspectGotAway) {
 				void playOutroScene();
+			} else {
+				playSfx('gameover');
 			}
 		});
 	});


### PR DESCRIPTION
Closes #53
Closes #26

## What

Adds a complete PC-speaker style sound layer to the game, synthesized at runtime with the Web Audio API — square-wave oscillators only, zero dependencies, no audio assets.

### Sound design
- **13 sounds** defined as data-driven note recipes in `src/lib/sfx.ts`: UI click (percussive pitch-drop), back, confirm, walking footsteps, prop-engine flying, witness clue chatter, low two-tone alarm, arrest sequence (whistle trills, running steps, cuff clicks), warrant computer, victory fanfare, sad-trombone game over, cricket sleep ambience, and teletype blips for the terminal typewriter.
- Animation-bound sounds match their durations: walk 1s, fly 2s, alarm 4s (trailing scenes), and sleep crickets stretch to the actual night length via `Clock.sleepDurationMs`.
- AudioContext is created lazily to respect autoplay policy; sounds queued while the context is suspended are dropped to avoid a noise burst on first interaction.

### Mute toggle
Persistent (localStorage) speaker toggle in the top-right of the layout, 50% opacity at rest. Muting is silent; unmuting plays a confirmation blip.

### Gameplay fixes found along the way
- Flying into sleep hours kept rendering the departure city (grayscale) all night and only swapped to the destination at wake (#26) — `Clock` now resolves movement promises before starting sleep, and `getClue` waits for morning via `waitForWake()` so clue reveals are unchanged.
- Catching the thief briefly flashed the chosen scene before redirecting to the outro — the final catch now goes straight to the outro.
- A decoy round visited from the final round could register a catch in the wrong city (`isLastRound` is index-based and decoys keep the index) — both catch paths now guard on `roundDecoy`.

## Testing

- `bun run check`, `bun run lint`, and unit tests pass
- Playwright e2e suite passes
- Sounds tuned by ear against the dev server across several iterations