### PR TITLE
fix: unlock sound effects on iOS

### DIFF
--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -257,6 +257,19 @@ export function playSfx(name: SfxName, durationMs?: number): void {
 	}
 }
 
+export function unlockSfx(): void {
+	try {
+		if (readMuted()) return;
+
+		const context = getAudioContext();
+		if (context === null || context.state === 'running') return;
+
+		void context.resume().catch(() => undefined);
+	} catch {
+		return;
+	}
+}
+
 export function setSfxMuted(muted: boolean): void {
 	mutedCache = muted;
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 	import SoundOff from '$lib/icons/SoundOff.svg.svelte';
 	import SoundOn from '$lib/icons/SoundOn.svg.svelte';
 	import { applyLocale } from '$lib/player';
-	import { isSfxMuted, playSfx, setSfxMuted } from '$lib/sfx';
+	import { isSfxMuted, playSfx, setSfxMuted, unlockSfx } from '$lib/sfx';
 	import { playerState } from '$lib/state/player.svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -34,6 +34,8 @@
 		});
 	});
 </script>
+
+<svelte:window onkeydown={unlockSfx} onpointerdown={unlockSfx} />
 
 <svelte:head>
 	<!-- Primary Meta Tags -->


### PR DESCRIPTION
## What

Fixes sound effects failing to play in iOS Safari by unlocking the Web Audio context from a user gesture.

- Adds an explicit `unlockSfx()` helper that resumes the existing lazy `AudioContext` when needed.
- Calls the unlock helper from top-level `pointerdown` and `keydown` events in the app layout, before delayed/effect-driven game sounds run.
- Keeps current `AudioContext` support only; no older `webkitAudioContext` fallback added.

## Testing

- `bun run check`